### PR TITLE
Allowing easier access to if the client is connected with a secret.

### DIFF
--- a/src/RelayConnection.ts
+++ b/src/RelayConnection.ts
@@ -9,9 +9,12 @@ class RelayConnection {
 
   public auth: AuthServiceToken | undefined;
 
+  public connectedWithSecret: boolean = false;
+
   constructor(server: RelayServer, socket: any) {
     this.server = server;
     this.socket = socket;
+    this.loadSecretFromQuery();
     this.loadAuthStateFromQuery();
     this.listenForMessages();
   }
@@ -23,10 +26,7 @@ class RelayConnection {
   listenForMessages() {
     this.socket.on("authStateChange", (data: any) => {
       if (!data.token) return;
-      this.auth = jsonwebtoken.verify(
-        data.token,
-        this.server.adamiteConfig.auth.secret
-      ) as AuthServiceToken;
+      this.auth = jsonwebtoken.verify(data.token, this.server.adamiteConfig.auth.secret) as AuthServiceToken;
     });
 
     this.socket.on("command", (data: any, callback: any) => {
@@ -37,16 +37,16 @@ class RelayConnection {
   }
 
   loadAuthStateFromQuery() {
-    if (
-      !this.socket.request._query.token ||
-      this.socket.request._query.token === ""
-    )
-      return;
+    if (!this.socket.request._query.token || this.socket.request._query.token === "") return;
     const token = this.socket.request._query.token;
-    this.auth = jsonwebtoken.verify(
-      token,
-      this.server.adamiteConfig.auth.secret
-    ) as AuthServiceToken;
+    this.auth = jsonwebtoken.verify(token, this.server.adamiteConfig.auth.secret) as AuthServiceToken;
+  }
+
+  loadSecretFromQuery() {
+    if (!this.socket.request._query.secret || this.socket.request._query.secret === "") {
+      return;
+    }
+    this.connectedWithSecret = true;
   }
 }
 


### PR DESCRIPTION
Now, for example, you can use this to bypass rules within your rules definitions...
```js
module.exports = {
  default: {
    pages: {
      read: (request, response) => {
        // allow secret auth
        if (request.client.connectedWithSecret) return true;

        return !response.data.deleted;
      }
    }
  }
}
```

Note: `connectedWithSecret` can be trusted, since Relay verifies the secret when the client connects, and then computes this property.